### PR TITLE
Do not set root of generated filesystem to /

### DIFF
--- a/live/live.go
+++ b/live/live.go
@@ -18,7 +18,6 @@ type Resources interface {
 // Dir returns an Resources implementation that servers the files from the
 // provided dir location, it will expand the path relative to the caller.
 func Dir(dir string) Resources {
-
 	_, filename, _, ok := runtime.Caller(1)
 
 	if !ok {
@@ -34,7 +33,6 @@ type resources struct {
 }
 
 func (r *resources) String(name string) (string, bool) {
-
 	file, err := r.Open(name)
 	if err != nil {
 		return "", false

--- a/resources.go
+++ b/resources.go
@@ -314,7 +314,7 @@ func (f *FileInfo) Sys() interface{} {
 func init() {
 	{{ .Var }} = &FileSystem{
 		files: map[string]File{
-			{{range $path, $file := .Files }}"/{{ $path }}": {{ template "file" $file }},{{ end }}
+			{{range $path, $file := .Files }}"{{ $path }}": {{ template "file" $file }},{{ end }}
 		},
 	}
 }

--- a/resources_test.go
+++ b/resources_test.go
@@ -5,38 +5,65 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omeid/go-resources/live"
 	"github.com/omeid/go-resources/testdata/generated"
 )
 
 //go:generate go build -o testdata/resources github.com/omeid/go-resources/cmd/resources
 //go:generate testdata/resources -package generated -declare -output testdata/generated/store_prod.go testdata/*.txt testdata/*.sql testdata/sub-a
 
-func TestGenerated(t *testing.T) {
-	for _, tt := range []struct {
-		name    string
-		snippet string
-	}{
-		{name: "test.txt", snippet: "this is test.txt"},
-		{name: "patrick.txt", snippet: "no, this is patrick!"},
-		{name: "query.sql", snippet: `drop table "files";`},
-		{name: "sub-a/test2.txt", snippet: "this is test2.txt"},
-		{name: "sub-a/sub-b/patrick2.txt", snippet: "no, this is patrick2!"},
-	} {
+var testCases = []struct {
+	name    string
+	snippet string
+}{
+	{name: "test.txt", snippet: "this is test.txt"},
+	{name: "patrick.txt", snippet: "no, this is patrick!"},
+	{name: "query.sql", snippet: `drop table "files";`},
+	{name: "sub-a/test2.txt", snippet: "this is test2.txt"},
+	{name: "sub-a/sub-b/patrick2.txt", snippet: "no, this is patrick2!"},
+}
+
+func TestLive(t *testing.T) {
+	liveDir := live.Dir("./testdata")
+
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			f, err := generated.FS.Open("/testdata/" + tt.name)
+			f, err := liveDir.Open(tt.name)
 
 			if err != nil {
-				t.Fatalf("expected no error opening file, got %v", err)
+				t.Fatalf("expected no error opening live file, got %v", err)
 			}
 			defer f.Close()
 
 			content, err := ioutil.ReadAll(f)
 			if err != nil {
-				t.Fatalf("expected no error reading file, got %v", err)
+				t.Fatalf("expected no error reading live file, got %v", err)
 			}
 
 			if !strings.Contains(string(content), tt.snippet) {
-				t.Errorf("expected to find snippet %q in file", tt.snippet)
+				t.Errorf("expected to find snippet %q in live file", tt.snippet)
+			}
+		})
+	}
+}
+
+func TestGenerated(t *testing.T) {
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := generated.FS.Open("testdata/" + tt.name)
+
+			if err != nil {
+				t.Fatalf("expected no error opening generated file, got %v", err)
+			}
+			defer f.Close()
+
+			content, err := ioutil.ReadAll(f)
+			if err != nil {
+				t.Fatalf("expected no error reading generated file, got %v", err)
+			}
+
+			if !strings.Contains(string(content), tt.snippet) {
+				t.Errorf("expected to find snippet %q in generated file", tt.snippet)
 			}
 		})
 	}


### PR DESCRIPTION
This makes generated paths consistent with live.Dir paths.

Also add tests for live.Dir.

Resolves #15 and #18.