### PR TITLE
Allow live.Dir to Work With Go Modules

### DIFF
--- a/live/live.go
+++ b/live/live.go
@@ -19,10 +19,9 @@ type Resources interface {
 // provided dir location, it will expand the path relative to the caller.
 func Dir(dir string) Resources {
 
-	_, filename, _, ok := runtime.Caller(1)
-
-	if !ok {
-		panic("failed to get Caller details")
+	filename, err := os.Executable()
+	if err != nil {
+		panic(err)
 	}
 
 	dir = filepath.Join(filepath.Dir(filename), dir)

--- a/live/live.go
+++ b/live/live.go
@@ -16,7 +16,7 @@ type Resources interface {
 }
 
 // Dir returns an Resources implementation that servers the files from the
-// provided dir location, it will expand the path relative to the caller.
+// provided dir location, it will expand the path relative to the executable.
 func Dir(dir string) Resources {
 
 	filename, err := os.Executable()


### PR DESCRIPTION
Currently, any repo that uses Go Modules will get an error if they try to open a file from `live.Dir`:

```
open github.com/chabad360/covey/assets/base.html: no such file or directory
```

This is because `live.Dir` uses `runtime.Caller` which returns the module path to the caller. This PR uses `os.Executable()` to fix that.

This PR fixes #18 (and doesn't require #19).